### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Note: Running a node only benefits you if you use your node to send and receive 
 1. Read how to <a href="https://github.com/6102bitcoin/FAQ/blob/master/hodl-privacy.md" target="_blank">Hodl Privately</a>
 2. Read about <a href="https://6102bitcoin.com/img/001_What_is_bitcoin_taint.png" target="_blank">What is bitcoin taint</a>,  <a href="https://6102bitcoin.com/img/002_Are_Chain_Analysis_Heuristics_Reliable.png" target="_blank">Are Chain Analysis Heuristics reliable</a> & <a href="https://6102bitcoin.com/img/003_Blacklisting_Distance_Proximity.png" target="_blank">Blacklisting, Distance & Proximity</a>
 3. Learn more about <a href="https://github.com/6102bitcoin/CoinJoin-Research/blob/master/CoinJoin_Research/CoinJoin_Discussion/CoinJoin_FAQ.md" target="_blank">CoinJoin</a>
+
 -----
 
 ## Step 10. Bitcoin MicroPayments


### PR DESCRIPTION
added space here. It is displaying the font in Cfrome on Step 9 Item 3 to have larger text. I assume this will fix it but I might be wrong. I couldn't see any other differences in formatting that is causing this.

![image](https://user-images.githubusercontent.com/25499388/78917227-36981700-7a54-11ea-9bb4-79b66b7e66e7.png)
