### PR TITLE
fix: Azteco "find vendors" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,6 @@ Though the methods explained in Step 2 are simple and easy for buying your first
 *Note: As stated when installing BISQ, the user is responsible for using the software in compliance with local laws.*
 
 ##### Vouchers
-0.  Check whether there are any merchants near you who sell vouchers on <a href="https://azte.co/vendors.html" target="_blank">Azteco</a> or <a href="https://fastbitcoins.com/#locations" target="_blank">FastBitcoins</a>
+0.  Check whether there are any merchants near you who sell vouchers on <a href="https://azte.co/" target="_blank">Azteco</a> or <a href="https://fastbitcoins.com/#locations" target="_blank">FastBitcoins</a>
 1.  If there aren't any local voucher vendors check out the below options. If there are, buy the minimum voucher denomination and follow the voucher instructions to redeem the bitcoin to your own wallet.
 2.  When prompted, paste your first bitcoin address from Step 1.


### PR DESCRIPTION
https://azte.co/vendors.html leads to a 404. The map now seems to be part of the main site https://azte.co/ - no deep link, it seems.